### PR TITLE
Content-Type header can be set manually for requests with data

### DIFF
--- a/lib/xhr-promise.js
+++ b/lib/xhr-promise.js
@@ -44,7 +44,7 @@ module.exports = XMLHttpRequestPromise = (function() {
     options = extend({}, defaults, options);
     return new Promise((function(_this) {
       return function(resolve, reject) {
-        var e, header, value, xhr, _ref;
+        var contentType, e, header, value, xhr, _ref;
         if (!XMLHttpRequest) {
           _this._handleError('browser', reject, null, "browser doesn't support XMLHttpRequest");
           return;
@@ -84,7 +84,13 @@ module.exports = XMLHttpRequestPromise = (function() {
         _this._attachWindowUnload();
         xhr.open(options.method, options.url, options.async, options.username, options.password);
         if (options.data != null) {
-          xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+          if (options.headers['Content-Type']) {
+            contentType = options.headers['Content-Type'];
+            delete options.headers['Content-Type'];
+          } else {
+            contentType = 'application/x-www-form-urlencoded; charset=UTF-8';
+          }
+          xhr.setRequestHeader('Content-Type', contentType);
         }
         _ref = options.headers;
         for (header in _ref) {

--- a/src/xhr-promise.coffee
+++ b/src/xhr-promise.coffee
@@ -74,7 +74,13 @@ module.exports = class XMLHttpRequestPromise
 
       xhr.open(options.method, options.url, options.async, options.username, options.password)
 
-      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8') if options.data?
+      if options.data?
+        if options.headers['Content-Type']
+          contentType = options.headers['Content-Type']
+          delete options.headers['Content-Type']
+        else
+          contentType = 'application/x-www-form-urlencoded; charset=UTF-8'
+        xhr.setRequestHeader('Content-Type', contentType)
 
       for header, value of options.headers
         xhr.setRequestHeader(header, value)

--- a/test/cases/request_test.js
+++ b/test/cases/request_test.js
@@ -80,7 +80,7 @@ describe('request', function () {
       });
   });
 
-  it('should set content-type header during POST', function (done) {
+  it('should set default content-type header during POST if not specified by the user', function (done) {
     new XMLHttpRequestPromise()
       .send({
         method: 'POST',
@@ -91,6 +91,24 @@ describe('request', function () {
         response.responseText.method.should.eql('POST');
         response.responseText.data.should.eql('foo=bar');
         response.responseText.headers['content-type'].should.eql('application/x-www-form-urlencoded; charset=UTF-8');
+        done();
+      });
+  });
+
+  it('should set content-type header during POST specified by the user', function (done) {
+    new XMLHttpRequestPromise()
+      .send({
+        method: 'POST',
+        url: '/request',
+        data: '{"foo":"bar"}',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+      .then(function (response) {
+        response.responseText.method.should.eql('POST');
+        response.responseText.data.should.eql('{"foo":"bar"}');
+        response.responseText.headers['content-type'].should.eql('application/json');
         done();
       });
   });


### PR DESCRIPTION
We're using the library to send JSON requests. In that case specifying Content-Type header doesn't work, because the library first sets the default `application/x-www-form-urlencoded` and then applies the defined header. Repeated calls to `xhr.setRequestHeader` [append, instead of replacing](http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader%28%29-method) and we end up with 

```
application/x-www-form-urlencoded; charset=UTF-8, application/json
```

The change checks whether the caller specified `Content-Type` and only if he didn't it uses the default value.
