### PR TITLE
README how to: your own polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This package is available on npm as:
 npm install xhr-promise
 ```
 
+Then:
+
+```
+var XHRPromise = require('xhr-promise'); //Will require Promise polyfill Zousan (+ ~2kB)
+```
+
+or
+
+```
+var XHRPromise = require('xhr-promise/lib/xhr-promise'); //Use your own Promise polyfill
+```
+
 ## Example
 
 The xhr-promise code in this example does the same thing as the following XMLHttpRequest code.


### PR DESCRIPTION
It took me some time to figure out that if you want to use your own Promise polyfill, solution is hidden in commit 18d8254fd3cc9ef519f4122bb1889b97fda52ff1
Better to show it on homepage.
